### PR TITLE
Add Lifecycle background app check to migration code

### DIFF
--- a/src/pages/documentation/tabs/migrate-to-swift.md
+++ b/src/pages/documentation/tabs/migrate-to-swift.md
@@ -12,11 +12,14 @@
 
 // AppDelegate.m
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+      const UIApplicationState appState = application.applicationState;
       [AEPMobileCore setLogLevel: AEPLogLevelDebug];
       [AEPMobileCore registerExtensions:@[AEPMobileSignal.class, AEPMobileLifecycle.class, AEPMobileUserProfile.class, AEPMobileIdentity.class, AEPMobileAssurance.class] completion:^{
         [AEPMobileCore configureWithAppId: @"yourAppId"];
-        [AEPMobileCore lifecycleStart:@{@"contextDataKey": @"contextDataVal"}];
-        }];
+        if (appState != UIApplicationStateBackground) {
+          [AEPMobileCore lifecycleStart:@{@"contextDataKey": @"contextDataVal"}];
+        }
+       }];
     ...
 }
 ```
@@ -33,9 +36,13 @@ import AEPSignal
 import AEPUserProfile
 
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    let appState = application.applicationState            
     MobileCore.registerExtensions([Signal.self, Lifecycle.self, UserProfile.self, Identity.self, Assurance.self], {
         MobileCore.configureWith(appId: "yourAppId")
-        MobileCore.lifecycleStart(additionalContextData: ["contextDataKey": "contextDataVal"])
+        if appState != .background {
+          // only start lifecycle if the application is not in the background
+          MobileCore.lifecycleStart(additionalContextData: ["contextDataKey": "contextDataVal"])
+        }
     })
   ...
 }


### PR DESCRIPTION
Our migration doc example code for lifecycle didn't have code showing the background app state check. This was confusing some customers.