### PR TITLE
Update the migration docs for Android and iOS

### DIFF
--- a/src/pages/documentation/migrate-to-android.md
+++ b/src/pages/documentation/migrate-to-android.md
@@ -49,23 +49,26 @@ If you are using Gradle to manage your app dependencies, the following example s
 
 ```java
 dependencies {
-    //replace sdk-core with Core/Lifecycle/Identity/Signal 2.0
-    //implementation 'com.adobe.marketing.mobile:sdk-core:1.+'
-    implementation 'com.adobe.marketing.mobile:core:2.+'
-    implementation 'com.adobe.marketing.mobile:lifecycle:2.+'
-    implementation 'com.adobe.marketing.mobile:identity:2.+'
-    implementation 'com.adobe.marketing.mobile:signal:2.+'
+    // The latest SDKs use bom to mange extension versions
+    // 1. Replace sdk-core with Core/Lifecycle/Identity/Signal
 
-    //replace UserProfile 1.+ with UserProfile 2.0
-    //implementation 'com.adobe.marketing.mobile:userprofile:1.+'
-    implementation 'com.adobe.marketing.mobile:userprofile:2.+'
+    // implementation 'com.adobe.marketing.mobile:sdk-core:1.+'
+    implementation platform('com.adobe.marketing.mobile:sdk-bom:3.+')
+    implementation 'com.adobe.marketing.mobile:core'
+    implementation 'com.adobe.marketing.mobile:identity'
+    implementation 'com.adobe.marketing.mobile:signal'
+    implementation 'com.adobe.marketing.mobile:lifecycle'
 
+    // 2. Replace other extension artifacts as below
+    
+    // implementation 'com.adobe.marketing.mobile:userprofile:1.+'
+    implementation 'com.adobe.marketing.mobile:userprofile'
 }
 ```
 
 <InlineAlert variant="warning" slots="text"/>
 
-Using dynamic dependency versions is not recommended for production apps. Refer to this [page](https://developer.adobe.com/client-sdks/documentation/manage-gradle-dependencies) for managing Gradle dependencies.
+Using dynamic dependency versions is not recommended for production apps. Refer to this [page](https://developer.adobe.com/client-sdks/resources/manage-gradle-dependencies/) for managing Gradle dependencies.
 
 Save the `build.gradle` file and select `Sync Project with Gradle Files` in Android Studio to download the latest Android SDK.
 
@@ -98,3 +101,13 @@ The `registerExtension` API for each extension is deprecated in the latest versi
 | `EXTENSION.registerExtension` | `MobileCore.registerExtensions` |
 | `UserProfile.updateUserAttribute` | `UserProfile.updateUserAttributes` |
 | `UserProfile.removeUserAttribute` | `UserProfile.removeUserAttributes` |
+
+## (Optional) Update the implementation of the network override
+
+Start from the SDK version 2.0, there have been breaking changes to overriding the default network service. The following classes have been removed in the latest SDKs. The implemetnation code working for overriding network service with the 1.x SDK  should be updated refering to this [documentation](https://developer.adobe.com/client-sdks/home/base/mobile-core/platform-services/network-service/).
+
+| Deprecated classes |
+| :------------- |
+| `AndroidNetworkServiceOverrider` |
+| `AndroidNetworkServiceOverrider.HTTPConnectionPerformer` |
+| `AndroidNetworkServiceOverrider.Connecting` |

--- a/src/pages/documentation/migrate-to-swift.md
+++ b/src/pages/documentation/migrate-to-swift.md
@@ -43,14 +43,16 @@ If you are manually importing SDK libraries, ensure you identify all currently u
 If you are using CocoaPods to manage your Adobe Experience Platform Mobile SDK dependencies, the following example shows you how to switch ACP-prefix libraries to AEP-prefix libraries in your `Podfile`.
 
 ```ruby
-# replace ACPCore with AEPCore/AEPLifecycle/AEPIdentity/AEPSignal
+# 1. Replace ACPCore with AEPCore/AEPLifecycle/AEPIdentity/AEPSignal
+
 # pod 'ACPCore'
   pod 'AEPCore'
   pod 'AEPLifecycle'
   pod 'AEPIdentity'
   pod 'AEPSignal'
 
-# replace ACPUserProfile with AEPUserProfile
+# 2. Replace other extension pods as below
+
 # pod 'ACPUserProfile'
   pod 'AEPUserProfile'
 ```
@@ -98,3 +100,13 @@ Finally, you'll need to scan through your current implementation and replace ACP
 | [Adobe Experience Platform Target](./adobe-target/index.md) | [AEPTarget](./adobe-target/migration.md) |
 | [Adobe Experience Platform Campaign](./adobe-campaign-standard/index.md) | [AEPCampaign](./adobe-campaign-standard/migration.md) |
 | [Adobe Experience Platform Campaign Classic](./adobe-campaign-classic/index.md) | [AEPCampaignClassic](./adobe-campaign-classic/migration.md) |
+
+## (Optional) Update the implementation of the network override
+
+In AEP-prefix SDK libraries, there have been breaking changes to overriding the default network service. The following interfaces have been removed in the latest SDKs. The implemetnation code working for overriding network service with the ACP-prefix SDK  should be updated refering to this [documentation](https://developer.adobe.com/client-sdks/home/base/mobile-core/platform-services/network-service/).
+
+| Deprecated interfaces |
+| :------------- |
+| `ACPNetworkServiceOverrider` |
+| `ACPHttpConnectionPerformer` |
+| `ACPHttpConnection` |


### PR DESCRIPTION
1. Migration doc for Android 
- Updated the dependency installation section to using the BOM artifacts
- Added missing information for `network override` use case

2. Migration doc for iOS
- Added missing information for `network override` use case

3. some cleanup